### PR TITLE
add config option to disable node label rendering

### DIFF
--- a/lib/render-arcs.js
+++ b/lib/render-arcs.js
@@ -68,16 +68,18 @@ function renderArcs (source, index, top, lane) {
         if (Array.isArray(top.edge)) {
             top.edge.map(archer);
         }
-        Object.keys(Events).map(function (k) {
-            if (k === k.toLowerCase()) {
-                if (Events[k].x > 0) {
-                    res = res.concat([renderLabel({
-                        x: Events[k].x,
-                        y: Events[k].y
-                    }, k + '')]);
+        if (!(top.config && top.config.nodes === false)) {
+            Object.keys(Events).map(function (k) {
+                if (k === k.toLowerCase()) {
+                    if (Events[k].x > 0) {
+                        res = res.concat([renderLabel({
+                            x: Events[k].x,
+                            y: Events[k].y
+                        }, k + '')]);
+                    }
                 }
-            }
-        });
+            });
+        }
     }
     return res;
 }


### PR DESCRIPTION
Allows for sharper diagrams without the node labels showing.

Addresses the "sharp lines without letters" from the user group